### PR TITLE
Enable release mode builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,3 +23,7 @@ jobs:
     with:
       runner_pool: nightly
       build_scheme: swift-statsd-client
+
+  release-builds:
+    name: Release builds
+    uses: apple/swift-nio/.github/workflows/release_builds.yml@main

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -31,3 +31,7 @@ jobs:
     with:
       runner_pool: general
       build_scheme: swift-statsd-client
+
+  release-builds:
+    name: Release builds
+    uses: apple/swift-nio/.github/workflows/release_builds.yml@main


### PR DESCRIPTION
Motivation:

Some errors do not show up in debug builds. Enabling release mode builds improves the CI coverage.

Modifications:

Enable release mode builds for pull requests and nightly builds on main.

Result:

Improved CI coverage.